### PR TITLE
FEATURE/BUGFIX: Add session-based authentication

### DIFF
--- a/Classes/Security/HashToken.php
+++ b/Classes/Security/HashToken.php
@@ -1,42 +1,12 @@
 <?php
 namespace Flownative\TokenAuthentication\Security;
 
-use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Security\Authentication\Token\AbstractToken;
 use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
-use Neos\Flow\Security\Exception\InvalidAuthenticationStatusException;
 
 /**
- * A Flow security token that authenticates based on a hash delivered.
+ * A Flow security token that authenticates based on a hash delivered
+ * without starting a session.
  */
-class HashToken extends AbstractToken implements SessionlessTokenInterface
+class HashToken extends SessionStartingHashToken implements SessionlessTokenInterface
 {
-    /**
-     * @var array
-     */
-    protected $credentials;
-
-    /**
-     * @param ActionRequest $actionRequest
-     * @return bool
-     * @throws InvalidAuthenticationStatusException
-     */
-    public function updateCredentials(ActionRequest $actionRequest)
-    {
-        $authenticationHashToken = $actionRequest->getHttpRequest()->getQueryParams()['_authenticationHashToken'] ?? null;
-
-        if (!$authenticationHashToken) {
-            $authorizationHeader = $actionRequest->getHttpRequest()->getHeader('Authorization');
-            if ($authorizationHeader) {
-                $authenticationHashToken = str_replace('Bearer ', '', $authorizationHeader);
-            }
-        }
-
-        if ($authenticationHashToken) {
-            $this->credentials['password'] = $authenticationHashToken;
-            $this->setAuthenticationStatus(self::AUTHENTICATION_NEEDED);
-        }
-
-        return false;
-    }
 }

--- a/Classes/Security/HashTokenProvider.php
+++ b/Classes/Security/HashTokenProvider.php
@@ -32,7 +32,7 @@ class HashTokenProvider extends AbstractProvider
      */
     public function getTokenClassNames(): array
     {
-        return [HashToken::class];
+        return [HashToken::class, SessionStartingHashToken::class];
     }
 
     /**
@@ -40,7 +40,7 @@ class HashTokenProvider extends AbstractProvider
      */
     public function authenticate(TokenInterface $authenticationToken)
     {
-        if (!($authenticationToken instanceof HashToken)) {
+        if (!($authenticationToken instanceof SessionStartingHashToken) && !($authenticationToken instanceof HashToken)) {
             throw new UnsupportedAuthenticationTokenException('This provider cannot authenticate the given token.', 1547118072);
         }
 

--- a/Classes/Security/SessionStartingHashToken.php
+++ b/Classes/Security/SessionStartingHashToken.php
@@ -1,0 +1,42 @@
+<?php
+namespace Flownative\TokenAuthentication\Security;
+
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Security\Authentication\Token\AbstractToken;
+use Neos\Flow\Security\Exception\InvalidAuthenticationStatusException;
+
+/**
+ * A Flow security token that authenticates based on a hash delivered and
+ * starts a session.
+ */
+class SessionStartingHashToken extends AbstractToken
+{
+    /**
+     * @var array
+     */
+    protected $credentials;
+
+    /**
+     * @param ActionRequest $actionRequest
+     * @return bool
+     * @throws InvalidAuthenticationStatusException
+     */
+    public function updateCredentials(ActionRequest $actionRequest)
+    {
+        $authenticationHashToken = $actionRequest->getHttpRequest()->getQueryParams()['_authenticationHashToken'] ?? null;
+
+        if (!$authenticationHashToken) {
+            $authorizationHeader = $actionRequest->getHttpRequest()->getHeader('Authorization');
+            if ($authorizationHeader) {
+                $authenticationHashToken = str_replace('Bearer ', '', $authorizationHeader);
+            }
+        }
+
+        if ($authenticationHashToken) {
+            $this->credentials['password'] = $authenticationHashToken;
+            $this->setAuthenticationStatus(self::AUTHENTICATION_NEEDED);
+        }
+
+        return false;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,17 +1,50 @@
 # Token based authentication for Neos Flow projects
 
+This package provides token based authentication for Neos Flow projects. It
+allows both sessionless and session-based authentication to be used.
+
 ## Installation
 
 Run:
 
-    composer require flownative/token-authentication    
+    composer require flownative/token-authentication
 
 ## Usage
 
 Run:
 
     ./flow hashtoken:createhashtoken --roleNames Neos.Neos:Editor
- 
-Provide token in your requests as request argument `_authenticationHashToken=<myToken>`.
 
-Or as `Authorization` header with the value `Bearer <myToken>`.
+Provide the token in your requests
+
+- as request argument `_authenticationHashToken=<myToken>` or
+- as `Authorization` header with the value `Bearer <myToken>`.
+
+## Configuration
+
+The configuration is done as usual in the `Configuration/Settings.yaml` file.
+
+```yaml
+Neos:
+  Flow:
+    security:
+      authentication:
+        providers:
+          'Acme.Com:TokenAuthenticator':
+            provider: Flownative\TokenAuthentication\Security\HashTokenProvider
+            requestPatterns:
+              'Acme.Com:Controllers':
+                pattern: ControllerObjectName
+                patternOptions:
+                  controllerObjectNamePattern: 'Acme\Com\Controller\.*'
+```
+
+By default the package uses a sessionless token. If you want to use a
+session-based token, set the `token` option in the provider configuration:
+
+```yaml
+providers:
+  'Acme.Com:TokenAuthenticator':
+    provider: Flownative\TokenAuthentication\Security\HashTokenProvider
+    token: Flownative\TokenAuthentication\Security\SessionStartingHashToken
+```


### PR DESCRIPTION
This commits add the possibility to use session-based authentication
with the package.

To be honest, it re-adds this, only v2.2.0 did not have it – before
authentication using this *always* started a session.

Now it defaults to sessionless but you can configure it to start a
session, should you need that.