### PR TITLE
BUGFIX: Stabilize SessionStartingHashToken

### DIFF
--- a/Classes/Security/SessionStartingHashToken.php
+++ b/Classes/Security/SessionStartingHashToken.php
@@ -18,30 +18,23 @@ class SessionStartingHashToken extends AbstractToken
 
     /**
      * @param ActionRequest $actionRequest
-     * @return bool
+     * @return void
      * @throws InvalidAuthenticationStatusException
      */
     public function updateCredentials(ActionRequest $actionRequest)
     {
         $authenticationHashToken = $actionRequest->getHttpRequest()->getQueryParams()['_authenticationHashToken'] ?? null;
 
-        if (!$authenticationHashToken) {
-            $authorizationHeaders = $actionRequest->getHttpRequest()->getHeader('Authorization');
-            if (!empty($authorizationHeaders)) {
-                foreach ($authorizationHeaders as $authorizationHeader) {
-                    if (strpos($authorizationHeader, 'Bearer ') === 0) {
-                        $authenticationHashToken = str_replace('Bearer ', '', $authorizationHeader);
-                        break;
-                    }
-                }
+        if ($authenticationHashToken === null) {
+            $authorizationHeader = $actionRequest->getHttpRequest()->getHeaderLine('Authorization');
+            if (strncmp($authorizationHeader, 'Bearer ', 7) === 0) {
+                $authenticationHashToken = substr($authorizationHeader, 7);
             }
         }
 
-        if ($authenticationHashToken) {
+        if ($authenticationHashToken !== null) {
             $this->credentials['password'] = $authenticationHashToken;
             $this->setAuthenticationStatus(self::AUTHENTICATION_NEEDED);
         }
-
-        return false;
     }
 }

--- a/Tests/Unit/SessionStartingHashTokenTest.php
+++ b/Tests/Unit/SessionStartingHashTokenTest.php
@@ -1,0 +1,117 @@
+<?php
+namespace Flownative\TokenAuthentication\Tests\Unit\Security;
+
+use Flownative\TokenAuthentication\Security\SessionStartingHashToken;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Security\Authentication\TokenInterface;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class SessionStartingHashTokenTest extends UnitTestCase
+{
+
+    /**
+     * @var SessionStartingHashToken
+     */
+    private $token;
+
+    /**
+     * @var ActionRequest|MockObject
+     */
+    private $mockActionRequest;
+
+    /**
+     * @var ServerRequestInterface|MockObject
+     */
+    private $mockHttpRequest;
+
+    protected function setUp(): void
+    {
+        $this->token = new SessionStartingHashToken();
+        $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
+
+        $this->mockHttpRequest = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $this->mockActionRequest->method('getHttpRequest')->willReturn($this->mockHttpRequest);
+    }
+
+    /**
+     * @test
+     */
+    public function updateCredentialsDoesNotSetCredentialsIfNoneArePresent(): void
+    {
+        $this->token->updateCredentials($this->mockActionRequest);
+        self::assertNull($this->token->getCredentials());
+    }
+
+    /**
+     * @test
+     */
+    public function updateCredentialsDoesNotAlterAuthenticationStatusIfNoCredentialsArePresent(): void
+    {
+        $this->token->updateCredentials($this->mockActionRequest);
+        self::assertSame(TokenInterface::NO_CREDENTIALS_GIVEN, $this->token->getAuthenticationStatus());
+    }
+
+    /**
+     * @test
+     */
+    public function updateCredentialsUpdatesCredentialsFromQueryParams(): void
+    {
+        $this->mockHttpRequest->method('getQueryParams')->willReturn(['_authenticationHashToken' => 'SomeToken']);
+        $this->token->updateCredentials($this->mockActionRequest);
+        self::assertSame(['password' => 'SomeToken'], $this->token->getCredentials());
+    }
+
+    /**
+     * @test
+     */
+    public function updateCredentialsUpdatesAuthenticationStatusIfTokenQueryParamIsSpecified(): void
+    {
+        $this->mockHttpRequest->method('getQueryParams')->willReturn(['_authenticationHashToken' => 'SomeToken']);
+        $this->token->updateCredentials($this->mockActionRequest);
+        self::assertSame(TokenInterface::AUTHENTICATION_NEEDED, $this->token->getAuthenticationStatus());
+    }
+
+    /**
+     * @test
+     */
+    public function updateCredentialsUpdatesCredentialsFromAuthorizationHeader(): void
+    {
+        $this->mockHttpRequest->method('getHeaderLine')->with('Authorization')->willReturn('Bearer SomeBearerToken');
+        $this->token->updateCredentials($this->mockActionRequest);
+        self::assertSame(['password' => 'SomeBearerToken'], $this->token->getCredentials());
+    }
+
+    /**
+     * @test
+     */
+    public function updateCredentialsUpdatesAuthenticationStatusIfAuthorizationHeaderIsSpecified(): void
+    {
+        $this->mockHttpRequest->method('getHeaderLine')->with('Authorization')->willReturn('Bearer SomeBearerToken');
+        $this->token->updateCredentials($this->mockActionRequest);
+        self::assertSame(TokenInterface::AUTHENTICATION_NEEDED, $this->token->getAuthenticationStatus());
+    }
+
+    /**
+     * @test
+     */
+    public function updateCredentialsIgnoresAuthorizationHeaderIfQueryParamIsSpecified(): void
+    {
+        $this->mockHttpRequest->method('getQueryParams')->willReturn(['_authenticationHashToken' => 'SomeTokenFromQueryParam']);
+        $this->mockHttpRequest->method('getHeaderLine')->with('Authorization')->willReturn('Bearer SomeTokenFromAuthHeader');
+        $this->token->updateCredentials($this->mockActionRequest);
+        self::assertSame(['password' => 'SomeTokenFromQueryParam'], $this->token->getCredentials());
+    }
+
+    /**
+     * @test
+     */
+    public function updateCredentialsIgnoresAuthorizationHeadersWithoutBearerPrefix(): void
+    {
+        $this->mockHttpRequest->method('getHeaderLine')->with('Authorization')->willReturn('SomeInvalidToken');
+        $this->token->updateCredentials($this->mockActionRequest);
+        self::assertNull($this->token->getCredentials());
+        self::assertSame(TokenInterface::NO_CREDENTIALS_GIVEN, $this->token->getAuthenticationStatus());
+    }
+}


### PR DESCRIPTION
Tweaks code and return type of `SessionStartingHashToken::updateCredentials()` and adds unit tests.

Related: #13